### PR TITLE
fix: add node text color

### DIFF
--- a/src/editor/Toolbox.tsx
+++ b/src/editor/Toolbox.tsx
@@ -12,7 +12,7 @@ export interface PreviewNodeProps<S extends Schema> {
 
 export function PreviewNode<S extends Schema>(props: PreviewNodeProps<S>) {
 	const context = useContext(CanvasContext)
-	const { borderColor, toolBoxImgWidth } = context.options
+	const { borderColor, textColor, toolBoxImgWidth } = context.options
 	const { backgroundColor, group, img } = props.kinds[props.kind]
 	const [_, drag] = useDrag({ type: "node", item: { group: group.archetype, action: group.action } })
 	return (
@@ -37,6 +37,7 @@ export function PreviewNode<S extends Schema>(props: PreviewNodeProps<S>) {
 					flex: 1,
 					marginLeft: portMargin / 2,
 					marginRight: portMargin / 2,
+					color: textColor,
 				}}
 			>
 				{group.archetype}

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,5 +1,6 @@
 export interface Options {
 	borderColor: string
+	textColor: string
 	backgroundColor: string
 	unit: number
 	height: number
@@ -14,6 +15,7 @@ export interface Options {
 
 export const defaultOptions: Options = {
 	borderColor: "dimgray",
+	textColor: "black",
 	backgroundColor: "lightgray",
 	unit: 20,
 	height: 100,


### PR DESCRIPTION
This is a small fix for node names being invisible in dark mode due to the text style getting inherited from the theme.